### PR TITLE
Move sbt release notes settings at build level

### DIFF
--- a/src/main/scala/sbtreleasenotes/ReleaseNotesPlugin.scala
+++ b/src/main/scala/sbtreleasenotes/ReleaseNotesPlugin.scala
@@ -51,11 +51,11 @@ object ReleaseNotesPlugin extends AutoPlugin {
 
   override lazy val buildSettings: Seq[Setting[_]] = Seq(
     releaseNotesFile := baseDirectory.value / "release-notes.md",
-    releaseNotesDraftFolder := baseDirectory.value / "release-notes"
+    releaseNotesDraftFolder := baseDirectory.value / "release-notes",
+    releaseNotesDraft := draftReleaseNotesTask.value
   )
 
-  override lazy val projectSettings = Seq(
-    releaseNotesDraft := draftReleaseNotesTask.value,
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
     releaseNotesUpdate := updateReleaseNotesTask.value,
     releaseNotesUpdate / releaseNotesUpdateCommitMessage := s"Update release notes for version ${version.value}"
   )

--- a/src/main/scala/sbtreleasenotes/ReleaseNotesPlugin.scala
+++ b/src/main/scala/sbtreleasenotes/ReleaseNotesPlugin.scala
@@ -52,12 +52,8 @@ object ReleaseNotesPlugin extends AutoPlugin {
   override lazy val buildSettings: Seq[Setting[_]] = Seq(
     releaseNotesFile := baseDirectory.value / "release-notes.md",
     releaseNotesDraftFolder := baseDirectory.value / "release-notes",
-    releaseNotesDraft := draftReleaseNotesTask.value
-  )
-
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    releaseNotesDraft := draftReleaseNotesTask.value,
     releaseNotesUpdate := updateReleaseNotesTask.value,
     releaseNotesUpdate / releaseNotesUpdateCommitMessage := s"Update release notes for version ${version.value}"
   )
-
 }

--- a/src/main/scala/sbtreleasenotes/ReleaseNotesTransformations.scala
+++ b/src/main/scala/sbtreleasenotes/ReleaseNotesTransformations.scala
@@ -88,7 +88,7 @@ object ReleaseNotesTransformations {
     val writer = new PrintWriter(releaseNotesDraftFile)
     writer.write(draftContent)
     writer.close()
-    println(s"Release-notes draft file created: $releaseNotesDraftFile")
+    streams.value.log.info(s"Release-notes draft file created: $releaseNotesDraftFile")
     releaseNotesDraftFile
   }
 


### PR DESCRIPTION
This enforces the fact that, as of now, a single release notes file is supported even in multi projects files. Fixes #81